### PR TITLE
fix workflow release tag checking step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+            fetch-depth: 0
 
       - name: Setup JAVA 17
         uses: actions/setup-java@v3
@@ -69,8 +71,7 @@ jobs:
       - name: Check if Tag Exists
         id: check_tag
         run: |
-          echo ${{ env.VERSION }}
-          if git rev-parse ${{ env.VERSION }} >/dev/null 2>&1; then
+          if git show-ref --tags | grep -q "${{ env.VERSION }}"; then
             echo "TAG_EXISTS=true" >> $GITHUB_ENV
           else
             echo "TAG_EXISTS=false" >> $GITHUB_ENV


### PR DESCRIPTION
### Fix workflow release step
Last [action](https://github.com/aniruddha-adhikary/mrt-buddy/actions/runs/11660130475) run failed as there was an existing release tag.

Now the workflow should fine! I have testing it on my branch

#20 