### PR TITLE
add workflow content write permissions for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
   workflow_dispatch: # Manually trigger the workflow
 
+permissions:
+  contents: write
+
 jobs:
   release_build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
fix: #20 

Following the official [docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions) I have added content write permission in our workflow.
