### PR TITLE
Incorporate date of the transactions

### DIFF
--- a/app/src/main/java/net/adhikary/mrtbuddy/nfc/parser/ByteParser.kt
+++ b/app/src/main/java/net/adhikary/mrtbuddy/nfc/parser/ByteParser.kt
@@ -15,4 +15,9 @@ class ByteParser {
 
     fun extractByte(bytes: ByteArray, offset: Int): Int =
         bytes[offset].toInt() and 0xFF
+
+    fun extractInt24BigEndian(bytes: ByteArray, offset: Int = 0): Int =
+        ((bytes[offset].toInt() and 0xFF) shl 16) or
+                ((bytes[offset + 1].toInt() and 0xFF) shl 8) or
+                (bytes[offset + 2].toInt() and 0xFF)
 }

--- a/app/src/main/java/net/adhikary/mrtbuddy/nfc/parser/TransactionParser.kt
+++ b/app/src/main/java/net/adhikary/mrtbuddy/nfc/parser/TransactionParser.kt
@@ -55,7 +55,7 @@ class TransactionParser(
         val fixedHeader = block.copyOfRange(0, 4)
         val fixedHeaderStr = byteParser.toHexString(fixedHeader)
 
-        val timestampValue = byteParser.extractInt16(block, 4)
+        val timestampValue = byteParser.extractInt24BigEndian(block, 4)
         val transactionTypeBytes = block.copyOfRange(6, 8)
         val transactionType = byteParser.toHexString(transactionTypeBytes)
 

--- a/app/src/main/java/net/adhikary/mrtbuddy/nfc/service/TimestampService.kt
+++ b/app/src/main/java/net/adhikary/mrtbuddy/nfc/service/TimestampService.kt
@@ -14,7 +14,7 @@ class TimestampService {
         val month = (value shr 13) and 0x0F
         val year = (value shr 17) and 0x1F
 
-        val date = GregorianCalendar(year + 2000, month, day, hour, 0)
+        val date = GregorianCalendar(year + 2000, month-1, day, hour, 0)
         return FORMAT.format(date.time)
     }
 }

--- a/app/src/main/java/net/adhikary/mrtbuddy/nfc/service/TimestampService.kt
+++ b/app/src/main/java/net/adhikary/mrtbuddy/nfc/service/TimestampService.kt
@@ -1,13 +1,20 @@
 package net.adhikary.mrtbuddy.nfc.service
 
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.GregorianCalendar
 
 class TimestampService {
+    companion object {
+        val FORMAT = SimpleDateFormat("dd MMM yyyy | hh:00 - hh:59 a")
+    }
+
     fun decodeTimestamp(value: Int): String {
-        val baseTime = System.currentTimeMillis() - (value * 60 * 1000L)
-        val date = Date(baseTime)
-        val format = SimpleDateFormat("yyyy-MM-dd HH:mm")
-        return format.format(date)
+        val hour = (value shr 3) and 0x1F
+        val day = (value shr 8) and 0x1F
+        val month = (value shr 13) and 0x0F
+        val year = (value shr 17) and 0x1F
+
+        val date = GregorianCalendar(year + 2000, month, day, hour, 0)
+        return FORMAT.format(date.time)
     }
 }

--- a/app/src/main/java/net/adhikary/mrtbuddy/ui/components/TransactionHistoryList.kt
+++ b/app/src/main/java/net/adhikary/mrtbuddy/ui/components/TransactionHistoryList.kt
@@ -92,6 +92,11 @@ fun TransactionItem(
                 text = if (type == TransactionType.Commute) "$fromStation → $toStation" else "Balance Update",
                 style = MaterialTheme.typography.bodyMedium
             )
+            Text(
+                text = date,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
         Column(
             horizontalAlignment = Alignment.End,


### PR DESCRIPTION
# This PR incorporates time with transaction
- [x] Fixed correct parsing of date
- [x] Added date in UI 

Closes: issue #8 

### Proof of concept:
<img src="https://github.com/user-attachments/assets/7ee9ace2-9f2d-4d1b-ab6d-0b657f2ef88e"  alt="proof" width="256"/>

### Theory

| Subject | Data |
| --- | --- |
| Transaction Bytes | 08 52 10 00 __31 65 48__ 01 14 01 23 76 01 00 00 B1 |
| Date-Time Entry | `31 65 48` -> `0011 0001 0110 0101 0100 1000` |

We can decode date and time after we split the date-time entry to bits (big endian):
| Element | Year | Month | Day | Hour | Padding |
| --- | --- | --- | --- | --- | --- |
| Binary | `0011 000` | `1 011` | `0 0101` |  `0100 1` | `000` |
| Decimal | 24 | 11 | 05 | 09 | - |

> [!NOTE]  
> We could not find any field related to minutes. So, we displayed the time as a range of one hour.