### PR TITLE
- feat: add map for metro and nearest metro (android)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -34,6 +34,10 @@ kotlin {
         androidMain.dependencies {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
+            implementation(libs.maps.compose)
+            implementation(libs.maps.compose.utils)
+            implementation(libs.play.services.maps)
+            implementation(libs.kotlinx.coroutines.play.services)
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -103,6 +107,7 @@ android {
 
 
 dependencies {
+    implementation(libs.play.services.location)
     add("kspAndroid", libs.androidx.room.compiler)
     add("kspIosSimulatorArm64", libs.androidx.room.compiler)
     add("kspIosX64", libs.androidx.room.compiler)

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -3,6 +3,10 @@
 
     <uses-permission android:name="android.permission.NFC" />
     <uses-feature android:name="android.hardware.nfc" android:required="true" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         android:allowBackup="true"
@@ -20,6 +24,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="AIzaSyBlEfGQAYuleAW_Vmh1alr56LHTPzak97E" />
+        <meta-data
+            android:name="com.google.android.gms.version"
+            android:value="@integer/google_play_services_version" />
+
+
     </application>
 
 </manifest>

--- a/composeApp/src/androidMain/kotlin/net/adhikary/mrtbuddy/ui/screens/map/MetroMap.android.kt
+++ b/composeApp/src/androidMain/kotlin/net/adhikary/mrtbuddy/ui/screens/map/MetroMap.android.kt
@@ -1,0 +1,343 @@
+package net.adhikary.mrtbuddy.ui.screens.map
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.BitmapDescriptor
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.LatLngBounds
+import com.google.maps.android.compose.CameraPositionState
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.MapUiSettings
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.Polyline
+import com.google.maps.android.compose.rememberCameraPositionState
+import mrtbuddy.composeapp.generated.resources.Res
+import mrtbuddy.composeapp.generated.resources.nav_map
+import mrtbuddy.composeapp.generated.resources.nearest_metro
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Created by Shakil Ahmed Shaj on 10,Nov,2024.
+ * shakilahmedshaj@gmail.com
+ */
+
+@Composable
+actual fun MetroMap() {
+    val context = LocalContext.current
+    val fusedLocationProviderClient = remember { LocationServices.getFusedLocationProviderClient(context) }
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(DEFAULT_LOCATION, DEFAULT_ZOOM)
+    }
+
+    var permissionGranted by remember { mutableStateOf(false) }
+    var currentLocation by remember { mutableStateOf<LatLng?>(null) }
+    var nearestStation by remember { mutableStateOf<MetroModel?>(null) }
+    var showDefaultMarker by remember { mutableStateOf(false) }
+
+    RequestLocationPermission {
+        permissionGranted = true
+    }
+
+    LaunchedEffect(currentLocation, nearestStation) {
+        if (currentLocation != null && nearestStation != null) {
+            val bounds = LatLngBounds.builder()
+                .include(currentLocation!!)
+                .include(nearestStation!!.location)
+                .build()
+            cameraPositionState.animate(
+                CameraUpdateFactory.newLatLngBounds(bounds, 100)
+            )
+        } else if (currentLocation != null) {
+            cameraPositionState.animate(
+                CameraUpdateFactory.newLatLngZoom(currentLocation!!, DEFAULT_ZOOM)
+            )
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        GoogleMapUI(
+            cameraPositionState = cameraPositionState,
+            permissionGranted = permissionGranted,
+            metroStations = METRO_STATIONS,
+            currentLocation = currentLocation,
+            nearestStation = nearestStation,
+            showDefaultMarker = showDefaultMarker
+        )
+
+        MoveToNearestMetroButton(
+            onMoveToLocation = {
+                if (permissionGranted) {
+                    handleCurrentLocation(
+                        fusedLocationProviderClient = fusedLocationProviderClient,
+                        onCurrentLocationUpdate = { location -> currentLocation = location },
+                        onNearestStationUpdate = { station -> nearestStation = station },
+                        stations = METRO_STATIONS,
+                        context = context
+                    )
+                }
+            },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(bottom = 120.dp, end = 8.dp) // padding to avoid screen edges
+        )
+    }
+}
+
+@Composable
+fun GoogleMapUI(
+    cameraPositionState: CameraPositionState,
+    permissionGranted: Boolean,
+    metroStations: List<MetroModel>,
+    currentLocation: LatLng?,
+    nearestStation: MetroModel?,
+    showDefaultMarker: Boolean
+) {
+    val context = LocalContext.current
+
+    GoogleMap(
+        modifier = Modifier.fillMaxSize(),
+        cameraPositionState = cameraPositionState,
+        uiSettings = MapUiSettings(
+            zoomControlsEnabled = false,
+            myLocationButtonEnabled = true,
+            compassEnabled = true
+        ),
+        properties = MapProperties(isMyLocationEnabled = permissionGranted)
+    ) {
+        metroStations.forEach { station ->
+            val markerState = remember { MarkerState(position = station.location) }
+
+            // Conditionally display the default marker
+            if (showDefaultMarker) {
+                Marker(
+                    state = markerState,
+                    title = station.name,
+                    snippet = if (station == nearestStation) "Nearest Metro Station" else null,
+                    icon = if (station == nearestStation) {
+                        BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_GREEN)
+                    } else {
+                        BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_RED)
+                    }
+                )
+            }
+
+            // Custom label marker
+            val isNearest = station == nearestStation
+            val offsetLocation = station.location.offset(0.0, 0.0002) // Adjust offset as needed
+            val labelBitmap = createCustomMarker(context, station.name, isNearest) // No `remember` here
+            Marker(
+                state = MarkerState(position = offsetLocation),
+                icon = labelBitmap
+            )
+        }
+
+        // Add a marker for the current location
+        currentLocation?.let { location ->
+            Marker(
+                state = MarkerState(position = location),
+                title = "Your Location",
+                icon = if (nearestStation != null) {
+                    BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_GREEN)
+                } else {
+                    BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE)
+                }
+            )
+        }
+
+        // Draw connecting lines between stations
+        if (metroStations.isNotEmpty()) {
+            Polyline(
+                points = metroStations.map { it.location },
+                color = Color.Blue,
+                width = 5f
+            )
+        }
+
+        // Draw a line between the current location and the nearest station
+        if (currentLocation != null && nearestStation != null) {
+            Polyline(
+                points = listOf(currentLocation, nearestStation.location),
+                color = Color.Green,
+                width = 5f
+            )
+        }
+    }
+}
+
+fun createCustomMarker(context: Context, text: String, isNearest: Boolean = false): BitmapDescriptor {
+    val baseHeight = 100
+    val padding = 20f // padding around the text
+
+    val textPaint = Paint().apply {
+        color = android.graphics.Color.WHITE
+        textSize = 36f // font size
+        isAntiAlias = true
+        textAlign = Paint.Align.CENTER
+    }
+
+    val textWidth = textPaint.measureText(text)
+    val markerWidth = (textWidth + (2 * padding)).toInt()
+    val markerHeight = baseHeight
+
+    val bitmap = Bitmap.createBitmap(markerWidth, markerHeight, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+
+    val backgroundPaint = Paint().apply {
+        color = if (isNearest) android.graphics.Color.GREEN else android.graphics.Color.RED
+        style = Paint.Style.FILL
+        isAntiAlias = true
+    }
+
+    // Draw rounded rectangle background
+    canvas.drawRoundRect(
+        0f,
+        0f,
+        markerWidth.toFloat(),
+        markerHeight.toFloat(),
+        20f, // Corner radius X
+        20f, // Corner radius Y
+        backgroundPaint
+    )
+
+    val xPos = markerWidth / 2f
+    val yPos = (markerHeight / 2f) - ((textPaint.descent() + textPaint.ascent()) / 2f)
+
+    canvas.drawText(text, xPos, yPos, textPaint)
+
+    return BitmapDescriptorFactory.fromBitmap(bitmap)
+}
+
+@Composable
+fun RequestLocationPermission(onPermissionGranted: () -> Unit) {
+    val context = LocalContext.current
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+        onResult = { isGranted -> if (isGranted) onPermissionGranted() }
+    )
+
+    LaunchedEffect(Unit) {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            onPermissionGranted()
+        } else {
+            launcher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+    }
+}
+
+@Composable
+fun MoveToNearestMetroButton(onMoveToLocation: () -> Unit, modifier: Modifier = Modifier) {
+    Button(
+        onClick = onMoveToLocation,
+        modifier = modifier
+    ) {
+        Text(stringResource(Res.string.nearest_metro))
+    }
+}
+
+fun handleCurrentLocation(
+    context: android.content.Context,
+    fusedLocationProviderClient: com.google.android.gms.location.FusedLocationProviderClient,
+    onCurrentLocationUpdate: (LatLng) -> Unit,
+    onNearestStationUpdate: (MetroModel?) -> Unit,
+    stations: List<MetroModel>
+) {
+    if (ActivityCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) != PackageManager.PERMISSION_GRANTED &&
+        ActivityCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_COARSE_LOCATION
+        ) != PackageManager.PERMISSION_GRANTED
+    ) {
+        Toast.makeText(context, "Location permission not granted", Toast.LENGTH_SHORT).show()
+        return
+    }
+
+    fusedLocationProviderClient.lastLocation.addOnSuccessListener { location ->
+        if (location == null) {
+            Toast.makeText(context, "Unable to fetch current location", Toast.LENGTH_SHORT).show()
+            return@addOnSuccessListener
+        }
+
+        val currentLatLng = LatLng(location.latitude, location.longitude)
+        onCurrentLocationUpdate(currentLatLng)
+
+        // Find the nearest metro station
+        val nearest = stations.minByOrNull { station ->
+            val dx = currentLatLng.latitude - station.location.latitude
+            val dy = currentLatLng.longitude - station.location.longitude
+            Math.sqrt(dx * dx + dy * dy)
+        }
+
+        onNearestStationUpdate(nearest)
+
+        nearest?.let {
+            Toast.makeText(context, "Nearest Metro Station: ${it.name}", Toast.LENGTH_SHORT).show()
+        } ?: Toast.makeText(context, "No nearby metro stations found", Toast.LENGTH_SHORT).show()
+    }.addOnFailureListener { e ->
+        Toast.makeText(context, "Error fetching location: ${e.message}", Toast.LENGTH_SHORT).show()
+    }
+}
+
+// for easy maintenance these value are placed below, once ios version developed, we should move these to separate files
+
+val DEFAULT_LOCATION = LatLng(23.798765492096376, 90.38918652845055)
+
+const val DEFAULT_ZOOM = 12f
+
+val METRO_STATIONS = listOf(
+    MetroModel("Uttara North", LatLng(23.869471207716987, 90.36755343277423)),
+    MetroModel("Uttara Center", LatLng(23.859678651226307, 90.3650513890263)),
+    MetroModel("Uttara South", LatLng(23.84755359557104, 90.36366587422005)),
+    MetroModel("Pallabi", LatLng(23.826305182548563, 90.3642373690619)),
+    MetroModel("Mirpur 11", LatLng(23.819318824040355, 90.36526741637955)),
+    MetroModel("Mirpur 10", LatLng(23.80859625981341, 90.36811057917744)),
+    MetroModel("Kazipara", LatLng(23.800611241398062, 90.37175651713184)),
+    MetroModel("Shewrapara", LatLng(23.791869924905853, 90.37557238552674)),
+    MetroModel("Agargaon", LatLng(23.77988914074858, 90.38008498964417)),
+    MetroModel("Bijoy Sarani", LatLng(23.76663577392801, 90.38315755342117)),
+    MetroModel("Farmgate", LatLng(23.759049516640832, 90.38699796246453)),
+    MetroModel("Karwan Bazar", LatLng(23.751260890448197, 90.39275548126527)),
+    MetroModel("Shahbagh", LatLng(23.739569746008907, 90.39606747923115)),
+    MetroModel("Dhaka University", LatLng(23.73188795267384, 90.39658925524438)),
+    MetroModel("Bangladesh Secretariat", LatLng(23.73002373248729, 90.40672048740873)),
+    MetroModel("Motijheel", LatLng(23.728058576887513, 90.41925162856687))
+)
+
+data class MetroModel(val name: String, val location: LatLng)
+
+fun LatLng.offset(latOffset: Double, lngOffset: Double): LatLng {
+    return LatLng(this.latitude + latOffset, this.longitude + lngOffset)
+}

--- a/composeApp/src/commonMain/composeResources/values-bn/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-bn/strings.xml
@@ -61,4 +61,9 @@
     <string name="rescanToCheckSufficientBalance">আপনার পর্যাপ্ত ব্যালেন্স আছে কিনা জানতে আপনার কার্ডটি পুনরায় স্ক্যান করুন</string>
     <string name="selectOrigin">শুরুর স্টেশন নির্বাচন করুন</string>
     <string name="selectDestination">গন্তব্য স্টেশন নির্বাচন করুন</string>
+
+    <!-- metro map-->
+    <string name="nav_map">ম্যাপ</string>
+    <string name="nearest_metro">সব চেয়ে কাছের মেট্রো</string>
+
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-en/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-en/strings.xml
@@ -61,4 +61,8 @@
     <string name="rescanToCheckSufficientBalance">Rescan your card to check if you have sufficient balance</string>
     <string name="selectOrigin">Select Origin Station</string>
     <string name="selectDestination">Select Destination Station</string>
+
+    <!-- metro map-->
+    <string name="nav_map">Map</string>
+    <string name="nearest_metro">Show Nearest Metro</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/components/Icons.kt
+++ b/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/components/Icons.kt
@@ -1,6 +1,9 @@
 package net.adhikary.mrtbuddy.ui.components
 
 import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.runtime.Composable
 import mrtbuddy.composeapp.generated.resources.Res
 import mrtbuddy.composeapp.generated.resources.calculate
@@ -19,6 +22,14 @@ public fun CalculatorIcon() {
 public fun CardIcon() {
     return Icon(
         painter = painterResource(Res.drawable.card),
+        contentDescription = "Calculate"
+    )
+}
+
+@Composable
+public fun MapIcon() {
+    return Icon(
+        imageVector = Icons.Default.LocationOn,
         contentDescription = "Calculate"
     )
 }

--- a/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/screens/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/screens/MainScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.dp
 import mrtbuddy.composeapp.generated.resources.Res
 import mrtbuddy.composeapp.generated.resources.balance
 import mrtbuddy.composeapp.generated.resources.fare
+import mrtbuddy.composeapp.generated.resources.nav_map
 import net.adhikary.mrtbuddy.model.CardState
 import net.adhikary.mrtbuddy.model.Transaction
 import net.adhikary.mrtbuddy.model.TransactionWithAmount
@@ -17,11 +18,13 @@ import net.adhikary.mrtbuddy.ui.components.BalanceCard
 import net.adhikary.mrtbuddy.ui.components.CalculatorIcon
 import net.adhikary.mrtbuddy.ui.components.CardIcon
 import net.adhikary.mrtbuddy.ui.components.Footer
+import net.adhikary.mrtbuddy.ui.components.MapIcon
 import net.adhikary.mrtbuddy.ui.components.TransactionHistoryList
 import org.jetbrains.compose.resources.stringResource
+import net.adhikary.mrtbuddy.ui.screens.map.MetroMap
 
 enum class Screen {
-    Home, Calculator
+    Home, Calculator, Map
 }
 
 @Composable
@@ -70,6 +73,15 @@ fun MainScreen(
                     selected = currentScreen == Screen.Calculator,
                     onClick = { currentScreen = Screen.Calculator }
                 )
+
+                BottomNavigationItem(
+                    icon = {
+                        MapIcon()
+                    },
+                    label = { Text(stringResource(Res.string.nav_map)) },
+                    selected = currentScreen == Screen.Map,
+                    onClick = { currentScreen = Screen.Map }
+                )
             }
         }
     ) { paddingValues ->
@@ -101,6 +113,10 @@ fun MainScreen(
             }
             Screen.Calculator -> {
                 FareCalculatorScreen(cardState = cardState)
+            }
+
+            Screen.Map -> {
+                MetroMap()
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/screens/map/MetroMap.kt
+++ b/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/screens/map/MetroMap.kt
@@ -1,0 +1,6 @@
+package net.adhikary.mrtbuddy.ui.screens.map
+
+import androidx.compose.runtime.Composable
+
+@Composable
+expect fun MetroMap()

--- a/composeApp/src/iosMain/kotlin/net/adhikary/mrtbuddy/ui/screens/map/MetroMap.ios.kt
+++ b/composeApp/src/iosMain/kotlin/net/adhikary/mrtbuddy/ui/screens/map/MetroMap.ios.kt
@@ -1,0 +1,28 @@
+package net.adhikary.mrtbuddy.ui.screens.map
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.sp
+
+@Composable
+actual fun MetroMap() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Coming Soon",
+            color = Color.Gray,
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.7.2"
-android-compileSdk = "34"
+android-compileSdk = "35"
 android-minSdk = "24"
 android-targetSdk = "34"
 androidx-activityCompose = "1.9.3"
@@ -19,6 +19,9 @@ kotlinxCoroutine = "1.9.0"
 androidx-room = "2.7.0-alpha11"
 ksp = "2.0.20-1.0.24"
 sqlite = "2.5.0-SNAPSHOT"
+mapsCompose = "6.2.1"
+playServicesMaps = "19.0.0"
+playServicesLocation = "21.3.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -38,6 +41,11 @@ kotlinx-coroutine = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", 
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "androidx-room" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "androidx-room" }
 sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
+maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "mapsCompose" }
+maps-compose-utils = { module = "com.google.maps.android:maps-compose-utils", version.ref = "mapsCompose" }
+play-services-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "playServicesMaps" }
+play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutine" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
https://github.com/user-attachments/assets/6f6e107f-565c-4944-aada-bf8ab77a24b5

This PR adds a Metro Location Map feature to the app, allowing users to view metro stations on a map and find the nearest metro station. It includes a new bottom tab for easy navigation to the map screen. All functionality is implemented without relying on paid Google APIs.

**Key Features**

 1. Displays all metro stations on an interactive map. Includes a "Show Nearest Metro" button to calculate and display the closest station based on the user's location. 
 2. Added a dedicated "Metro Map" tab for easy access to the feature.

**Notes:**

 1. No reliance on paid APIs
 2. Implemented manual geospatial calculations for finding the nearest
    station.

**PS: Implemented only for Android**
