### PR TITLE
feat: add dynamic color settings

### DIFF
--- a/composeApp/src/androidMain/kotlin/net/adhikary/mrtbuddy/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/net/adhikary/mrtbuddy/MainActivity.kt
@@ -23,7 +23,7 @@ class MainActivity : ComponentActivity() {
         Napier.d("App Running.....")
 
         setContent {
-            App(dynamicColor = true)
+            App(dynamicColor = supportsDynamicColor)
         }
     }
 }
@@ -31,5 +31,5 @@ class MainActivity : ComponentActivity() {
 @Preview
 @Composable
 fun AppAndroidPreview() {
-    App(dynamicColor = true)
+    App(dynamicColor = supportsDynamicColor)
 }

--- a/composeApp/src/androidMain/kotlin/net/adhikary/mrtbuddy/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/net/adhikary/mrtbuddy/Platform.android.kt
@@ -9,3 +9,6 @@ class AndroidPlatform : Platform {
 actual fun getPlatform(): Platform = AndroidPlatform()
 
 actual val isDebug: Boolean = BuildConfig.DEBUG
+
+actual val supportsDynamicColor: Boolean
+    get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S

--- a/composeApp/src/androidMain/kotlin/net/adhikary/mrtbuddy/ui/theme/Theme.android.kt
+++ b/composeApp/src/androidMain/kotlin/net/adhikary/mrtbuddy/ui/theme/Theme.android.kt
@@ -1,11 +1,11 @@
 package net.adhikary.mrtbuddy.ui.theme
 
-import android.os.Build
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import net.adhikary.mrtbuddy.supportsDynamicColor
 
 @Composable
 actual fun MRTBuddyTheme(
@@ -14,7 +14,7 @@ actual fun MRTBuddyTheme(
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+        dynamicColor && supportsDynamicColor -> {
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }

--- a/composeApp/src/commonMain/composeResources/drawable/colors.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/colors.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M346,820 L100,574q-10,-10 -15,-22t-5,-25q0,-13 5,-25t15,-22l230,-229 -106,-106 62,-65 400,400q10,10 14.5,22t4.5,25q0,13 -4.5,25T686,574L440,820q-10,10 -22,15t-25,5q-13,0 -25,-5t-22,-15ZM393,314L179,528h428L393,314ZM792,840q-36,0 -61,-25.5T706,752q0,-27 13.5,-51t30.5,-47l42,-54 44,54q16,23 30,47t14,51q0,37 -26,62.5T792,840Z"
+      android:fillColor="#e8eaed"/>
+</vector>

--- a/composeApp/src/commonMain/composeResources/values-bn/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-bn/strings.xml
@@ -74,6 +74,9 @@
     <string name="helpAndSupportButton">সাহায্য</string>
     <string name="nonAffiliationDisclaimer">এটি একটি স্বাধীন প্রকল্প এবং এটি ঢাকা ম্যাস ট্রানজিট কোম্পানি লিমিটেড (ডিএমটিসিএল) দ্বারা আনুষ্ঠানিকভাবে অনুমোদিত বা সংযুক্ত নয়।</string>
     <string name="readOnlyDisclaimer">অ্যাপটি শুধুমাত্র কার্ডের তথ্য পড়তে সক্ষম, এবং কার্ডের ব্যালেন্স রিচার্জ, টপ-আপ বা পরিবর্তন করতে সক্ষম নয়।</string>
+    <string name="dynamicColor">ডায়নামিক রং</string>
+    <string name="on">চালু</string>
+    <string name="off">বন্ধ</string>
 
     <!-- History and Transaction screens -->
     <string name="transactions">লেনদেন</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -93,6 +93,9 @@
     <string name="unnamedCard">Unnamed Card</string>
     <string name="cardId">Card ID</string>
     <string name="lastScan">Last Scan</string>
+    <string name="dynamicColor">Dynamic Color</string>
+    <string name="on">On</string>
+    <string name="off">Off</string>
     
     <!-- Settings screen -->
     <string name="settings">Settings</string>

--- a/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/App.kt
+++ b/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/App.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import net.adhikary.mrtbuddy.managers.RescanManager
 import net.adhikary.mrtbuddy.nfc.getNFCManager
+import net.adhikary.mrtbuddy.repository.SettingsRepository
 import net.adhikary.mrtbuddy.ui.screens.home.MainScreen
 import net.adhikary.mrtbuddy.ui.screens.home.MainScreenAction
 import net.adhikary.mrtbuddy.ui.screens.home.MainScreenEvent
@@ -17,6 +18,7 @@ import net.adhikary.mrtbuddy.ui.screens.home.MainScreenViewModel
 import net.adhikary.mrtbuddy.ui.theme.MRTBuddyTheme
 import net.adhikary.mrtbuddy.utils.observeAsActions
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -26,6 +28,7 @@ fun App(
     dynamicColor: Boolean
 ) {
     val mainVm = koinViewModel<MainScreenViewModel>()
+    val settingsRepository: SettingsRepository = koinInject()
     val scope = rememberCoroutineScope()
     val nfcManager = getNFCManager()
 
@@ -60,12 +63,13 @@ fun App(
         }
     }
 
+    val isDynamicColor by settingsRepository.isDynamicColorEnabled.collectAsState()
 
     nfcManager.startScan()
 
     MRTBuddyTheme(
         darkTheme = darkTheme,
-        dynamicColor = dynamicColor
+        dynamicColor = dynamicColor && isDynamicColor
     ) {
         val state: MainScreenState by mainVm.state.collectAsState()
 

--- a/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/Platform.kt
@@ -7,3 +7,5 @@ interface Platform {
 expect fun getPlatform(): Platform
 
 expect val isDebug: Boolean
+
+expect val supportsDynamicColor: Boolean

--- a/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/repository/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/repository/SettingsRepository.kt
@@ -13,6 +13,9 @@ class SettingsRepository(private val settings: Settings) {
     private val _currentLanguage = MutableStateFlow(settings.getString(LANGUAGE_KEY, Language.English.isoFormat))
     val currentLanguage: StateFlow<String> = _currentLanguage.asStateFlow()
 
+    private val _isDynamicColorEnabled = MutableStateFlow(settings.getBoolean(DYNAMIC_COLOR_KEY, false))
+    val isDynamicColorEnabled: StateFlow<Boolean> = _isDynamicColorEnabled.asStateFlow()
+
     fun setAutoSave(enabled: Boolean) {
         settings.putBoolean(AUTO_SAVE_KEY, enabled)
         _autoSaveEnabled.value = enabled
@@ -23,8 +26,14 @@ class SettingsRepository(private val settings: Settings) {
         _currentLanguage.value = language
     }
 
+    fun setDynamicColor(enabled: Boolean) {
+        settings.putBoolean(DYNAMIC_COLOR_KEY, enabled)
+        _isDynamicColorEnabled.value = enabled
+    }
+
     companion object {
         private const val AUTO_SAVE_KEY = "auto_save_enabled"
         private const val LANGUAGE_KEY = "app_language"
+        private const val DYNAMIC_COLOR_KEY = "dynamic_color_enabled"
     }
 }

--- a/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/screens/more/MoreScreen.kt
+++ b/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/screens/more/MoreScreen.kt
@@ -29,12 +29,16 @@ import mrtbuddy.composeapp.generated.resources.Res
 import mrtbuddy.composeapp.generated.resources.aboutHeader
 import mrtbuddy.composeapp.generated.resources.autoSaveCardDetails
 import mrtbuddy.composeapp.generated.resources.autoSaveCardDetailsDescription
+import mrtbuddy.composeapp.generated.resources.colors
 import mrtbuddy.composeapp.generated.resources.contributors
+import mrtbuddy.composeapp.generated.resources.dynamicColor
 import mrtbuddy.composeapp.generated.resources.help
 import mrtbuddy.composeapp.generated.resources.helpAndSupportButton
 import mrtbuddy.composeapp.generated.resources.language
 import mrtbuddy.composeapp.generated.resources.license
 import mrtbuddy.composeapp.generated.resources.nonAffiliationDisclaimer
+import mrtbuddy.composeapp.generated.resources.off
+import mrtbuddy.composeapp.generated.resources.on
 import mrtbuddy.composeapp.generated.resources.openSourceLicenses
 import mrtbuddy.composeapp.generated.resources.others
 import mrtbuddy.composeapp.generated.resources.policy
@@ -44,6 +48,7 @@ import mrtbuddy.composeapp.generated.resources.settings
 import mrtbuddy.composeapp.generated.resources.stationMap
 import mrtbuddy.composeapp.generated.resources.station_map
 import net.adhikary.mrtbuddy.Language
+import net.adhikary.mrtbuddy.supportsDynamicColor
 import net.adhikary.mrtbuddy.ui.screens.more.MoreScreenAction
 import net.adhikary.mrtbuddy.ui.screens.more.MoreScreenEvent
 import net.adhikary.mrtbuddy.ui.screens.more.MoreScreenViewModel
@@ -131,6 +136,22 @@ fun MoreScreen(
                     viewModel.onAction(MoreScreenAction.StationMap)
                 }
             )
+            
+            if (supportsDynamicColor) {
+                RoundedButton(
+                    text = stringResource(Res.string.dynamicColor),
+                    painter = painterResource(Res.drawable.colors),
+                    onClick = {
+                        viewModel.onAction(MoreScreenAction.SetDynamicColor(!uiState.isDynamicColorEnabled))
+                    },
+                    trailing = {
+                        Text(
+                            text = stringResource(if (uiState.isDynamicColorEnabled) Res.string.on else Res.string.off),
+                            modifier = Modifier.padding(end = 8.dp)
+                        )
+                    }
+                )
+            }
 
             SectionHeader(text = stringResource(Res.string.aboutHeader))
             RoundedButton(

--- a/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/screens/more/MoreScreenAction.kt
+++ b/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/screens/more/MoreScreenAction.kt
@@ -5,5 +5,6 @@ sealed interface MoreScreenAction {
     data class SetAutoSave(val enabled: Boolean) : MoreScreenAction
     data class SetLanguage(val language: String) : MoreScreenAction
     object StationMap : MoreScreenAction
+    data class SetDynamicColor(val enabled: Boolean) : MoreScreenAction
     object OpenLicenses : MoreScreenAction
 }

--- a/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/screens/more/MoreScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/screens/more/MoreScreenState.kt
@@ -4,5 +4,6 @@ data class MoreScreenState(
     val isLoading: Boolean = false,
     val autoSaveEnabled: Boolean = false,
     val currentLanguage: String = "en",
+    val isDynamicColorEnabled: Boolean = false,
     val error: String? = null
 )

--- a/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/screens/more/MoreScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/net/adhikary/mrtbuddy/ui/screens/more/MoreScreenViewModel.kt
@@ -32,9 +32,11 @@ class MoreScreenViewModel(
                     try {
                         val autoSaveEnabled = settingsRepository.autoSaveEnabled.value
                         val currentLanguage = settingsRepository.currentLanguage.value
+                        val isDynamicColorEnabled = settingsRepository.isDynamicColorEnabled.value
                         _state.value = _state.value.copy(
                             autoSaveEnabled = autoSaveEnabled,
-                            currentLanguage = currentLanguage
+                            currentLanguage = currentLanguage,
+                            isDynamicColorEnabled = isDynamicColorEnabled
                         )
                     } catch (e: Exception) {
                         _state.value = _state.value.copy(error = e.message)
@@ -75,6 +77,15 @@ class MoreScreenViewModel(
             is MoreScreenAction.StationMap -> {
                 viewModelScope.launch {
                     _events.send(MoreScreenEvent.NavigateTooStationMap)
+            
+            is MoreScreenAction.SetDynamicColor -> {
+                viewModelScope.launch {
+                    try {
+                        settingsRepository.setDynamicColor(action.enabled)
+                        _state.value = _state.value.copy(isDynamicColorEnabled = action.enabled)
+                    } catch (e: Exception) {
+                        _events.send(MoreScreenEvent.Error(e.message ?: "Failed to change dynamic color"))
+                    }
                 }
             }
         }

--- a/composeApp/src/iosMain/kotlin/net/adhikary/mrtbuddy/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/net/adhikary/mrtbuddy/MainViewController.kt
@@ -21,5 +21,5 @@ fun MainViewController() = ComposeUIViewController {
         Napier.base(DebugAntilog())
     }
 
-    App(dynamicColor = false)
+    App(dynamicColor = supportsDynamicColor)
 }

--- a/composeApp/src/iosMain/kotlin/net/adhikary/mrtbuddy/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/net/adhikary/mrtbuddy/Platform.ios.kt
@@ -12,3 +12,6 @@ actual fun getPlatform(): Platform = IOSPlatform()
 
 @OptIn(ExperimentalNativeApi::class)
 actual val isDebug: Boolean = kotlinPlatform.isDebugBinary
+
+actual val supportsDynamicColor: Boolean
+    get() = false


### PR DESCRIPTION
Enable dynamic color toggling if the device supports Monet; disabled by default. This allows users to choose between using Monet colors and the original theme.

| Dynamic Color Disabled | Dynamic Color Enabled |
| :---: | :---: |
| ![Screenshot_20241127-155306_MRT Buddy](https://github.com/user-attachments/assets/d10e2182-8d23-4b6f-ac3d-d3324af838f0) | ![Screenshot_20241127-155313_MRT Buddy](https://github.com/user-attachments/assets/2e9cdfc2-1044-4dee-9a49-fac8152ca9f3) |
| ![Screenshot_20241127-155235_MRT Buddy](https://github.com/user-attachments/assets/aef28a4a-0794-4a0e-8278-0aa45fd48a56) | ![Screenshot_20241127-155232_MRT Buddy](https://github.com/user-attachments/assets/3571329f-fdb2-4f6a-a0f6-a5a2da19c8be) |
